### PR TITLE
Fix App test import path

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
-import App from './App';
+import App from './components/App/App';
 
-test('renders learn react link', () => {
+test('renders Dragon Slayer heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByRole('heading', { name: /dragon slayer/i });
+  expect(heading).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- update the test to use the real App component
- check that the Dragon Slayer heading renders

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68522ab6e9148323bf7574ab7251ccc3