### PR TITLE
Improve fight logic and share utils

### DIFF
--- a/src/components/Cave.jsx
+++ b/src/components/Cave.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react"
 import "./App/App.css"
 import murlocimg from "./App/assests/murloc.png"
 import sludgerimg from "./App/assests/sludger.png"
+import { enemyAttackValue, isEnemyHit, resetAfterDefeat } from "../utils/fightUtils"
 
 const Cave = ({ onReturnClick, health, setHealth, gold, setGold, inventory, setMode, xp, setXp, currentWeaponIndex }) => {
 
@@ -24,53 +25,32 @@ const Cave = ({ onReturnClick, health, setHealth, gold, setGold, inventory, setM
 
     //function to hold logic for player attack
     const playerAttack = () => {
-        if (!inventory[currentWeaponIndex]){
+        if (!inventory[currentWeaponIndex]) {
             alert("You don't have a weapon, go to the store buy one")
+            return;
         }
+
         if (isEnemyHit()) { //if hit is landed
-            const damage = inventory[currentWeaponIndex]?.power + Math.floor(Math.random() * xp) //number of damage = the weapon power level + the calculated player xp
-            setEnemyHealth(prevHealth => prevHealth - damage) //subtract damage from current health to update state
+            const damage = inventory[currentWeaponIndex]?.power + Math.floor(Math.random() * xp); //damage = weapon power + player xp factor
+            setEnemyHealth(prevHealth => prevHealth - damage); //subtract damage from current health
             if (enemyHealth - damage <= 0) {
-                alert(`${enemy.name} defeated! You gained XP and gold!`)
+                alert(`${enemy.name} defeated! You gained XP and gold!`);
                 setXp(xp + enemyPower);
                 setGold(gold + 20);
-                setIsFighting(false)
-            } 
-            //test
-
+                setIsFighting(false);
+                return; //enemy defeated, stop further actions
+            }
         } else {
-            alert("you missed!")
+            alert("you missed!");
         }
-        const enemyDamage = enemyAttackValue();
-        setHealth(health - enemyDamage)
+
+        const enemyDamage = enemyAttackValue(enemyPower, xp);
+        setHealth(health - enemyDamage);
         if (health - enemyDamage <= 0) {
-            alert("You have been defeated! The game will reset.")
-            handleDefeat()
+            alert("You have been defeated! The game will reset.");
+            resetAfterDefeat(setHealth, setEnemy, setIsFighting, setMode);
         }
     };
-
-    //get enemy attack value based on enemy power and player xp
-    const enemyAttackValue = () => {
-        return enemyPower * 5 - Math.floor(Math.random() * xp)
-    };
-
-    //set 80% chance of player hitting enemy
-    const isEnemyHit = () => {
-        return Math.random() > 0.2
-    };
-
-
-    // player loses fight once health reaches 0 then game will reset
-    const handleDefeat = () => {
-        setHealth(100); // Reset player's health
-        setEnemy(null); // Clear the current enemy
-        setIsFighting(false); // Exit fight mode
-        setTimeout(() => {
-            setMode('start'); // Return to Start Menu
-        }, 2000); // Wait for 2 seconds before returning to start
-    }
-
-
 
     return (
 

--- a/src/components/DragonFight.jsx
+++ b/src/components/DragonFight.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react"
 import "./App/App.css"
 import dragonimg from "./App/assests/dragonimg.jpg"
+import { enemyAttackValue, isEnemyHit, resetAfterDefeat } from "../utils/fightUtils"
 
 const DragonFight = ({ onReturnClick, health, setHealth, gold, setGold, inventory, xp, setXp, currentWeaponIndex, setMode }) => {
     const dragon = { name: 'Dragon', power: 20, health: 300 };
@@ -19,6 +20,11 @@ const DragonFight = ({ onReturnClick, health, setHealth, gold, setGold, inventor
     }, [enemy]);
 
     const playerAttack = () => {
+        if (!inventory[currentWeaponIndex]) {
+            alert("You don't have a weapon, go to the store buy one");
+            return;
+        }
+
         if (isEnemyHit()) {
             const damage = inventory[currentWeaponIndex]?.power + Math.floor(Math.random() * xp);
             setEnemyHealth(prevHealth => prevHealth - damage);
@@ -27,34 +33,21 @@ const DragonFight = ({ onReturnClick, health, setHealth, gold, setGold, inventor
                 setXp(xp + enemyPower);
                 setGold(gold + 100); // More gold for defeating the dragon
                 setIsFighting(false);
+                return;
             }
         } else {
             alert("You missed!");
         }
-        const enemyDamage = enemyAttackValue();
+
+        const enemyDamage = enemyAttackValue(enemyPower, xp);
         setHealth(health - enemyDamage);
         if (health - enemyDamage <= 0) {
             alert("You have been defeated by the Dragon! The game will reset.");
-            handleDefeat();
+            resetAfterDefeat(setHealth, setEnemy, setIsFighting, setMode);
         }
     };
 
-    const enemyAttackValue = () => {
-        return enemyPower * 5 - Math.floor(Math.random() * xp);
-    };
 
-    const isEnemyHit = () => {
-        return Math.random() > 0.2;
-    };
-
-    const handleDefeat = () => {
-        setHealth(100);
-        setEnemy(null);
-        setIsFighting(false);
-        setTimeout(() => {
-            setMode('start');
-        }, 2000);
-    };
 
     return (
         <>
@@ -70,7 +63,7 @@ const DragonFight = ({ onReturnClick, health, setHealth, gold, setGold, inventor
       {isFighting ? (
         <>
         <img src={dragonimg} alt="Ferocious dragon" />
-          <p>Dragon: {dragon.name} (Health: {dragon.health})</p>
+          <p>Dragon: {enemy.name} (Health: {enemyHealth})</p>
           <div className="button-container">
           <button onClick={playerAttack}>Attack</button>
           <button onClick={() => setIsFighting(false)}>Run</button>

--- a/src/utils/fightUtils.js
+++ b/src/utils/fightUtils.js
@@ -1,0 +1,16 @@
+export const enemyAttackValue = (enemyPower, xp) => {
+  return Math.max(0, enemyPower * 5 - Math.floor(Math.random() * xp));
+};
+
+export const isEnemyHit = () => {
+  return Math.random() > 0.2;
+};
+
+export const resetAfterDefeat = (setHealth, setEnemy, setIsFighting, setMode) => {
+  setHealth(100);
+  setEnemy(null);
+  setIsFighting(false);
+  setTimeout(() => {
+    setMode('start');
+  }, 2000);
+};


### PR DESCRIPTION
## Summary
- prevent attacking without a weapon
- stop extra damage after defeating enemies
- make dragon health display dynamic
- avoid negative enemy damage with shared helper
- extract common fight helpers

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68522e0e41208323bf965b0da10ab395