### PR TITLE
Add TextModal component and integrate message system

### DIFF
--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -86,3 +86,41 @@ img {
   width: 100%; /* Buttons take full width */
   margin-bottom: 10px;
 }
+
+/* Modal Styles */
+.text-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.6);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.text-modal {
+  background-color: #2c2f33;
+  color: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 4px 15px rgba(0,0,0,0.5);
+  max-width: 400px;
+  text-align: center;
+}
+
+.text-modal button {
+  margin-top: 10px;
+  background-color: #007bff;
+  color: #fff;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.text-modal button:hover {
+  background-color: #0056b3;
+}

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -6,6 +6,7 @@ import Store from '../Store';
 import Cave from '../Cave';
 import DragonFight from '../DragonFight';
 import usePlayer from '../Player';
+import TextModal from '../TextModal';
 
 //define App component 
 const App = () => {
@@ -13,6 +14,7 @@ const App = () => {
   //define player using usePlayer hook and initialize game modes
   const player = usePlayer();
   const [mode, setMode] = useState('start');
+  const [message, setMessage] = useState('');
 
   const changeMode = (newMode) => setMode(newMode);
   const onReturnClick = () => changeMode('townHall'); //add handler to return to previous mode
@@ -28,9 +30,10 @@ const App = () => {
           onReturnToStart={() => changeMode('start')}
         />
       )}
-      {mode === 'cave' && <Cave {...player} onReturnClick={onReturnClick} />}
+      {mode === 'cave' && <Cave {...player} onReturnClick={onReturnClick} setMessage={setMessage} />}
       {mode === 'store' && <Store {...player} setMode={setMode} onReturnClick={onReturnClick}/>}
-      {mode === 'dragonFight' && <DragonFight {...player} setMode={setMode} onReturnClick={onReturnClick}/>}
+      {mode === 'dragonFight' && <DragonFight {...player} setMode={setMode} onReturnClick={onReturnClick} setMessage={setMessage} />}
+      <TextModal message={message} onClose={() => setMessage('')} />
     </div>
   );
 };

--- a/src/components/Cave.jsx
+++ b/src/components/Cave.jsx
@@ -4,7 +4,7 @@ import murlocimg from "./App/assests/murloc.png"
 import sludgerimg from "./App/assests/sludger.png"
 import { enemyAttackValue, isEnemyHit, resetAfterDefeat } from "../utils/fightUtils"
 
-const Cave = ({ onReturnClick, health, setHealth, gold, setGold, inventory, setMode, xp, setXp, currentWeaponIndex }) => {
+const Cave = ({ onReturnClick, health, setHealth, gold, setGold, inventory, setMode, xp, setXp, currentWeaponIndex, setMessage }) => {
 
     const caveEnemies = [
         { name: 'Sludger', power: 2, health: 15 },
@@ -26,7 +26,7 @@ const Cave = ({ onReturnClick, health, setHealth, gold, setGold, inventory, setM
     //function to hold logic for player attack
     const playerAttack = () => {
         if (!inventory[currentWeaponIndex]) {
-            alert("You don't have a weapon, go to the store buy one")
+            setMessage("You don't have a weapon, go to the store buy one");
             return;
         }
 
@@ -34,20 +34,20 @@ const Cave = ({ onReturnClick, health, setHealth, gold, setGold, inventory, setM
             const damage = inventory[currentWeaponIndex]?.power + Math.floor(Math.random() * xp); //damage = weapon power + player xp factor
             setEnemyHealth(prevHealth => prevHealth - damage); //subtract damage from current health
             if (enemyHealth - damage <= 0) {
-                alert(`${enemy.name} defeated! You gained XP and gold!`);
+                setMessage(`${enemy.name} defeated! You gained XP and gold!`);
                 setXp(xp + enemyPower);
                 setGold(gold + 20);
                 setIsFighting(false);
                 return; //enemy defeated, stop further actions
             }
         } else {
-            alert("you missed!");
+            setMessage("you missed!");
         }
 
         const enemyDamage = enemyAttackValue(enemyPower, xp);
         setHealth(health - enemyDamage);
         if (health - enemyDamage <= 0) {
-            alert("You have been defeated! The game will reset.");
+            setMessage("You have been defeated! The game will reset.");
             resetAfterDefeat(setHealth, setEnemy, setIsFighting, setMode);
         }
     };

--- a/src/components/DragonFight.jsx
+++ b/src/components/DragonFight.jsx
@@ -3,7 +3,7 @@ import "./App/App.css"
 import dragonimg from "./App/assests/dragonimg.jpg"
 import { enemyAttackValue, isEnemyHit, resetAfterDefeat } from "../utils/fightUtils"
 
-const DragonFight = ({ onReturnClick, health, setHealth, gold, setGold, inventory, xp, setXp, currentWeaponIndex, setMode }) => {
+const DragonFight = ({ onReturnClick, health, setHealth, gold, setGold, inventory, xp, setXp, currentWeaponIndex, setMode, setMessage }) => {
     const dragon = { name: 'Dragon', power: 20, health: 300 };
     const [isFighting, setIsFighting] = useState(false);
 
@@ -21,7 +21,7 @@ const DragonFight = ({ onReturnClick, health, setHealth, gold, setGold, inventor
 
     const playerAttack = () => {
         if (!inventory[currentWeaponIndex]) {
-            alert("You don't have a weapon, go to the store buy one");
+            setMessage("You don't have a weapon, go to the store buy one");
             return;
         }
 
@@ -29,20 +29,20 @@ const DragonFight = ({ onReturnClick, health, setHealth, gold, setGold, inventor
             const damage = inventory[currentWeaponIndex]?.power + Math.floor(Math.random() * xp);
             setEnemyHealth(prevHealth => prevHealth - damage);
             if (enemyHealth - damage <= 0) {
-                alert(`${enemy.name} defeated! You gained XP and gold!`);
+                setMessage(`${enemy.name} defeated! You gained XP and gold!`);
                 setXp(xp + enemyPower);
                 setGold(gold + 100); // More gold for defeating the dragon
                 setIsFighting(false);
                 return;
             }
         } else {
-            alert("You missed!");
+            setMessage("You missed!");
         }
 
         const enemyDamage = enemyAttackValue(enemyPower, xp);
         setHealth(health - enemyDamage);
         if (health - enemyDamage <= 0) {
-            alert("You have been defeated by the Dragon! The game will reset.");
+            setMessage("You have been defeated by the Dragon! The game will reset.");
             resetAfterDefeat(setHealth, setEnemy, setIsFighting, setMode);
         }
     };

--- a/src/components/TextModal.jsx
+++ b/src/components/TextModal.jsx
@@ -1,13 +1,16 @@
-import React, { useState } from 'react';
+import React from 'react';
 
-const TextModal = () => {
-const [text, setText] = useState("")
+const TextModal = ({ message, onClose }) => {
+  if (!message) return null;
 
-    return (
-        <>
-        
-        </>
-    )
-}
+  return (
+    <div className="text-modal-overlay">
+      <div className="text-modal">
+        <p>{message}</p>
+        <button onClick={onClose}>Close</button>
+      </div>
+    </div>
+  );
+};
 
-export default TextModal
+export default TextModal;


### PR DESCRIPTION
## Summary
- implement `TextModal` component for displaying messages
- wire modal into `App` component with message state
- replace `alert` calls in `Cave` and `DragonFight` with modal messages
- style modal in `App.css`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685239460fb883238a04d745e54f93cd