### PR TITLE
Add localStorage persistence for player stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The following technologies were used to build this app:
 - Health Monitoring: Both player and dragon have health that depletes with each successful hit.
 - Randomized Outcomes: The game uses random chance to vary the impact of attacks and defense moves, keeping gameplay dynamic.
 - Victory and Defeat Conditions: The game ends with either victory or defeat based on health points.
+- Persistent Player Progress: Your health, gold, inventory and experience are saved in your browser so you can continue later. Use the reset option in game to clear your progress.
 
 ## Game Play Visuals
 ![town hall image](/public/d_s_img1.png)

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -21,7 +21,9 @@ const App = () => {
 
   return (
     <div>
-      {mode === 'start' && <StartMenu onStart={() => changeMode('townHall')} />}
+      {mode === 'start' && (
+        <StartMenu onStart={() => changeMode('townHall')} onReset={player.resetPlayer} />
+      )}
       {mode === 'townHall' && (
         <TownHall
           onEnterCave={() => changeMode('cave')}

--- a/src/components/Player.jsx
+++ b/src/components/Player.jsx
@@ -1,16 +1,66 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import "./App/App.css"
 
 
 //define usePlayer hook
 const usePlayer = () => {
 
-  //initialize all Player stats
-  const [health, setHealth] = useState(100);
-  const [gold, setGold] = useState(150);
-  const [inventory, setInventory] = useState([]);
-  const [xp, setXp] = useState(0);
-  const [currentWeaponIndex, setCurrentWeaponIndex] = useState(-1);
+  //initialize all Player stats, loading from localStorage if available
+  const [health, setHealth] = useState(() => {
+    const saved = localStorage.getItem('health');
+    return saved !== null ? JSON.parse(saved) : 100;
+  });
+  const [gold, setGold] = useState(() => {
+    const saved = localStorage.getItem('gold');
+    return saved !== null ? JSON.parse(saved) : 150;
+  });
+  const [inventory, setInventory] = useState(() => {
+    const saved = localStorage.getItem('inventory');
+    return saved !== null ? JSON.parse(saved) : [];
+  });
+  const [xp, setXp] = useState(() => {
+    const saved = localStorage.getItem('xp');
+    return saved !== null ? JSON.parse(saved) : 0;
+  });
+  const [currentWeaponIndex, setCurrentWeaponIndex] = useState(() => {
+    const saved = localStorage.getItem('currentWeaponIndex');
+    return saved !== null ? JSON.parse(saved) : -1;
+  });
+
+  //sync state to localStorage whenever it changes
+  useEffect(() => {
+    localStorage.setItem('health', JSON.stringify(health));
+  }, [health]);
+
+  useEffect(() => {
+    localStorage.setItem('gold', JSON.stringify(gold));
+  }, [gold]);
+
+  useEffect(() => {
+    localStorage.setItem('inventory', JSON.stringify(inventory));
+  }, [inventory]);
+
+  useEffect(() => {
+    localStorage.setItem('xp', JSON.stringify(xp));
+  }, [xp]);
+
+  useEffect(() => {
+    localStorage.setItem('currentWeaponIndex', JSON.stringify(currentWeaponIndex));
+  }, [currentWeaponIndex]);
+
+  //reset function to clear storage and reinitialize state
+  const resetPlayer = () => {
+    localStorage.removeItem('health');
+    localStorage.removeItem('gold');
+    localStorage.removeItem('inventory');
+    localStorage.removeItem('xp');
+    localStorage.removeItem('currentWeaponIndex');
+    setHealth(100);
+    setGold(150);
+    setInventory([]);
+    setXp(0);
+    setCurrentWeaponIndex(-1);
+  };
 
   return {
     
@@ -24,7 +74,8 @@ const usePlayer = () => {
     setXp,
     currentWeaponIndex,
     setCurrentWeaponIndex,
-   
+    resetPlayer,
+
   };
 };
 

--- a/src/components/StartMenu.jsx
+++ b/src/components/StartMenu.jsx
@@ -2,7 +2,7 @@ import React, { useState } from "react"
 import "./App/App.css"
 import dragonStartImg from "./App/assests/dragonbackground.png"
 
-const StartMenu = ({ onStart }) => {
+const StartMenu = ({ onStart, onReset }) => {
     return (
         <>
         <div className="game-container">
@@ -14,6 +14,7 @@ const StartMenu = ({ onStart }) => {
           fearsome creatures, and protect the realm?</p>
         <div className="button-container">
         <button onClick={onStart}>Start Game</button>
+        {onReset && <button onClick={onReset}>Reset Game</button>}
       </div>
       </div>
       </>
@@ -21,4 +22,3 @@ const StartMenu = ({ onStart }) => {
   };
   
   export default StartMenu;
-  


### PR DESCRIPTION
## Summary
- persist player state in `usePlayer` with localStorage and add reset helper
- expose reset handler from StartMenu UI
- allow App to pass reset function to StartMenu
- document progress saving and reset option in README

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68523f3be1d483239805b3400d6250fa