### PR TITLE
Add component tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,14 @@ Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
 The page will reload when you make changes.\
 You may also see any lint errors in the console.
 
+
+### Running Tests
+
+Execute the unit tests with:
+
+```
+npm test
+```
+
+This command runs Jest in the project and executes all test files.
+

--- a/src/components/Cave.test.jsx
+++ b/src/components/Cave.test.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Cave from './Cave';
+
+jest.mock('../utils/fightUtils', () => ({
+  isEnemyHit: jest.fn(() => true),
+  enemyAttackValue: jest.fn(() => 5),
+  resetAfterDefeat: jest.fn(),
+}));
+
+function Wrapper() {
+  const [health, setHealth] = React.useState(100);
+  const [gold, setGold] = React.useState(0);
+  const [inventory, setInventory] = React.useState([{ name: 'Stick', power: 5 }]);
+  const [xp, setXp] = React.useState(0);
+  const [currentWeaponIndex, setCurrentWeaponIndex] = React.useState(0);
+  const [mode, setMode] = React.useState('cave');
+  const [message, setMessage] = React.useState('');
+
+  return (
+    <Cave
+      onReturnClick={() => {}}
+      health={health}
+      setHealth={setHealth}
+      gold={gold}
+      setGold={setGold}
+      inventory={inventory}
+      setMode={setMode}
+      xp={xp}
+      setXp={setXp}
+      currentWeaponIndex={currentWeaponIndex}
+      setMessage={setMessage}
+    />
+  );
+}
+
+describe('Cave combat', () => {
+  test('attacking enemy reduces player health', async () => {
+    render(<Wrapper />);
+
+    await userEvent.click(screen.getByRole('button', { name: /fight sludger/i }));
+    await userEvent.click(screen.getByRole('button', { name: /attack/i }));
+
+    expect(screen.getByText(/health: 95/i)).toBeInTheDocument();
+  });
+});
+
+

--- a/src/components/DragonFight.test.jsx
+++ b/src/components/DragonFight.test.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DragonFight from './DragonFight';
+
+jest.mock('../utils/fightUtils', () => ({
+  isEnemyHit: jest.fn(() => true),
+  enemyAttackValue: jest.fn(() => 5),
+  resetAfterDefeat: jest.fn(),
+}));
+
+function Wrapper() {
+  const [health, setHealth] = React.useState(100);
+  const [gold, setGold] = React.useState(0);
+  const [inventory, setInventory] = React.useState([{ name: 'Stick', power: 5 }]);
+  const [xp, setXp] = React.useState(0);
+  const [currentWeaponIndex, setCurrentWeaponIndex] = React.useState(0);
+  const [mode, setMode] = React.useState('dragonFight');
+  const [message, setMessage] = React.useState('');
+
+  return (
+    <DragonFight
+      onReturnClick={() => {}}
+      health={health}
+      setHealth={setHealth}
+      gold={gold}
+      setGold={setGold}
+      inventory={inventory}
+      xp={xp}
+      setXp={setXp}
+      currentWeaponIndex={currentWeaponIndex}
+      setMode={setMode}
+      setMessage={setMessage}
+    />
+  );
+}
+
+describe('DragonFight combat', () => {
+  test('attacking dragon reduces player health', async () => {
+    render(<Wrapper />);
+
+    await userEvent.click(screen.getByRole('button', { name: /fight dragon/i }));
+    await userEvent.click(screen.getByRole('button', { name: /attack/i }));
+
+    expect(screen.getByText(/health: 95/i)).toBeInTheDocument();
+  });
+});
+
+

--- a/src/components/Store.test.jsx
+++ b/src/components/Store.test.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Store from './Store';
+
+function Wrapper() {
+  const [health, setHealth] = React.useState(100);
+  const [gold, setGold] = React.useState(40);
+  const [inventory, setInventory] = React.useState([]);
+  const [currentWeaponIndex, setCurrentWeaponIndex] = React.useState(-1);
+
+  return (
+    <Store
+      onReturnClick={() => {}}
+      health={health}
+      setHealth={setHealth}
+      gold={gold}
+      setGold={setGold}
+      inventory={inventory}
+      setInventory={setInventory}
+      currentWeaponIndex={currentWeaponIndex}
+      setCurrentWeaponIndex={setCurrentWeaponIndex}
+    />
+  );
+}
+
+
+describe('Store actions', () => {
+  test('buyItem adds a weapon and subtracts gold', async () => {
+    render(<Wrapper />);
+
+    // Buy first weapon
+    await userEvent.click(screen.getByRole('button', { name: /buy stick/i }));
+    expect(screen.getByText(/gold: 10/i)).toBeInTheDocument();
+    expect(screen.getByText(/inventory: stick/i)).toBeInTheDocument();
+  });
+
+  test('sellItem removes a weapon and adds gold', async () => {
+    render(<Wrapper />);
+
+    // buy then sell
+    await userEvent.click(screen.getByRole('button', { name: /buy stick/i }));
+    await userEvent.click(screen.getByRole('button', { name: /sell weapon/i }));
+
+    expect(screen.getByText(/gold: 25/i)).toBeInTheDocument();
+    expect(screen.getByText(/inventory: empty/i)).toBeInTheDocument();
+  });
+
+  test('buyHealth increases health and costs gold', async () => {
+    render(<Wrapper />);
+
+    await userEvent.click(screen.getByRole('button', { name: /buy health/i }));
+    expect(screen.getByText(/health: 110/i)).toBeInTheDocument();
+    expect(screen.getByText(/gold: 30/i)).toBeInTheDocument();
+  });
+});
+
+

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,3 +3,5 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+global.alert = jest.fn();


### PR DESCRIPTION
## Summary
- add missing tests for store actions
- test health reduction in Cave and DragonFight
- mock `alert` globally for Jest
- document how to run the tests

## Testing
- `CI=true npm test -- -u` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68523f9bf2a08323b6f29de0ae528338