### PR TITLE
Fix StartMenu component

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -22,6 +22,7 @@ const App = () => {
 
   return (
     <div>
+      {mode === 'start' && <StartMenu onStart={() => changeMode('townHall')} />}
       {mode === 'townHall' && (
         <TownHall
           onEnterCave={() => changeMode('cave')}

--- a/src/components/StartMenu.jsx
+++ b/src/components/StartMenu.jsx
@@ -2,24 +2,24 @@ import React from "react";
 import "./App/App.css";
 import dragonStartImg from "./App/assests/dragonbackground.png";
 
-
-    return (
-        <>
-        <div className="game-container">
+const StartMenu = ({ onStart }) => {
+  return (
+    <>
+      <div className="game-container">
         <h1>Dragon Slayer</h1>
         <img src={dragonStartImg} alt="Dragon with a fiery background" />
-        <p>The fate of the kingdom rests in your hands. 
-          Begin your journey and prepare to face the challenges ahead. 
-          Are you ready to step into the world of adventure, fight 
-          fearsome creatures, and protect the realm?</p>
+        <p>
+          The fate of the kingdom rests in your hands. Begin your journey and
+          prepare to face the challenges ahead. Are you ready to step into the
+          world of adventure, fight fearsome creatures, and protect the realm?
+        </p>
         <div className="button-container">
-        <button onClick={onStart}>Start Game</button>
+          <button onClick={onStart}>Start Game</button>
+        </div>
+      </div>
+    </>
+  );
+};
 
-      </div>
-      </div>
-      </>
-    );
-  };
-  
-  export default StartMenu;
+export default StartMenu;
 


### PR DESCRIPTION
## Summary
- fix `StartMenu` component definition
- render `StartMenu` when App loads

## Testing
- `CI=true npm test --silent` *(fails: unable to find text `/health: 95/i` in some tests)*

------
https://chatgpt.com/codex/tasks/task_e_6852434318988323986c0473e7d0c22a