### PR TITLE
Implement damage notification modals

### DIFF
--- a/src/components/Cave.jsx
+++ b/src/components/Cave.jsx
@@ -50,8 +50,10 @@ const Cave = ({ onReturnClick, health, setHealth, gold, setGold, inventory, setM
         }
 
         const enemyDamage = enemyAttackValue(enemyPower, xp);
-        setHealth(health - enemyDamage);
-        if (health - enemyDamage <= 0) {
+        const newHealth = health - enemyDamage;
+        setHealth(newHealth);
+        setMessage(`You took ${enemyDamage} damage!`);
+        if (newHealth <= 0) {
             setMessage("You have been defeated! The game will reset.");
             resetAfterDefeat(setHealth, setEnemy, setIsFighting, setMode);
         }

--- a/src/components/Cave.test.jsx
+++ b/src/components/Cave.test.jsx
@@ -40,9 +40,10 @@ describe('Cave combat', () => {
     render(<Wrapper />);
 
     await userEvent.click(screen.getByRole('button', { name: /fight sludger/i }));
+    await screen.findByText(/enemy: sludger \(health: 15\)/i);
     await userEvent.click(screen.getByRole('button', { name: /attack/i }));
 
-    expect(screen.getByText(/health: 95/i)).toBeInTheDocument();
+    await screen.findByText(/health: 95/i);
   });
 });
 

--- a/src/components/DragonFight.jsx
+++ b/src/components/DragonFight.jsx
@@ -46,8 +46,10 @@ const DragonFight = ({ onReturnClick, health, setHealth, gold, setGold, inventor
         }
 
         const enemyDamage = enemyAttackValue(enemyPower, xp);
-        setHealth(health - enemyDamage);
-        if (health - enemyDamage <= 0) {
+        const newHealth = health - enemyDamage;
+        setHealth(newHealth);
+        setMessage(`You took ${enemyDamage} damage!`);
+        if (newHealth <= 0) {
             setMessage("You have been defeated by the Dragon! The game will reset.");
             resetAfterDefeat(setHealth, setEnemy, setIsFighting, setMode);
         }

--- a/src/components/DragonFight.test.jsx
+++ b/src/components/DragonFight.test.jsx
@@ -40,9 +40,10 @@ describe('DragonFight combat', () => {
     render(<Wrapper />);
 
     await userEvent.click(screen.getByRole('button', { name: /fight dragon/i }));
+    await screen.findByText(/dragon: dragon \(health: 300\)/i);
     await userEvent.click(screen.getByRole('button', { name: /attack/i }));
 
-    expect(screen.getByText(/health: 95/i)).toBeInTheDocument();
+    await screen.findByText(/health: 95/i);
   });
 });
 


### PR DESCRIPTION
## Summary
- show modal when player takes damage in the cave
- show modal when player takes damage from the dragon
- adjust tests

## Testing
- `npm test --silent -- --watchAll=false` *(fails: Unable to find health text in DOM)*

------
https://chatgpt.com/codex/tasks/task_e_685248a80538832395940b764f358641