### PR TITLE
Reset player stats on defeat

### DIFF
--- a/src/components/Cave.jsx
+++ b/src/components/Cave.jsx
@@ -5,7 +5,7 @@ import sludgerimg from "./App/assests/sludger.png";
 import { enemyAttackValue, isEnemyHit, resetAfterDefeat } from "../utils/fightUtils";
 import useAudioManager from "../utils/useAudioManager";
 
-const Cave = ({ onReturnClick, health, setHealth, gold, setGold, inventory, setMode, xp, setXp, currentWeaponIndex, setMessage, isMuted }) => {
+const Cave = ({ onReturnClick, health, setHealth, gold, setGold, inventory, setMode, xp, setXp, currentWeaponIndex, setMessage, isMuted, resetPlayer }) => {
 
     const caveEnemies = [
         { name: 'Sludger', power: 2, health: 15 },
@@ -55,7 +55,7 @@ const Cave = ({ onReturnClick, health, setHealth, gold, setGold, inventory, setM
         setMessage(`You took ${enemyDamage} damage!`);
         if (newHealth <= 0) {
             setMessage("You have been defeated! The game will reset.");
-            resetAfterDefeat(setHealth, setEnemy, setIsFighting, setMode);
+            resetAfterDefeat(resetPlayer, setEnemy, setIsFighting, setMode);
         }
     };
 

--- a/src/components/DragonFight.jsx
+++ b/src/components/DragonFight.jsx
@@ -4,7 +4,7 @@ import dragonimg from "./App/assests/dragonimg.jpg";
 import { enemyAttackValue, isEnemyHit, resetAfterDefeat } from "../utils/fightUtils";
 import useAudioManager from "../utils/useAudioManager";
 
-const DragonFight = ({ onReturnClick, health, setHealth, gold, setGold, inventory, xp, setXp, currentWeaponIndex, setMode, setMessage, isMuted }) => {
+const DragonFight = ({ onReturnClick, health, setHealth, gold, setGold, inventory, xp, setXp, currentWeaponIndex, setMode, setMessage, isMuted, resetPlayer }) => {
     const dragon = { name: 'Dragon', power: 20, health: 300 };
     const [isFighting, setIsFighting] = useState(false);
 
@@ -51,7 +51,7 @@ const DragonFight = ({ onReturnClick, health, setHealth, gold, setGold, inventor
         setMessage(`You took ${enemyDamage} damage!`);
         if (newHealth <= 0) {
             setMessage("You have been defeated by the Dragon! The game will reset.");
-            resetAfterDefeat(setHealth, setEnemy, setIsFighting, setMode);
+            resetAfterDefeat(resetPlayer, setEnemy, setIsFighting, setMode);
         }
     };
 

--- a/src/utils/fightUtils.js
+++ b/src/utils/fightUtils.js
@@ -6,8 +6,8 @@ export const isEnemyHit = () => {
   return Math.random() > 0.2;
 };
 
-export const resetAfterDefeat = (setHealth, setEnemy, setIsFighting, setMode) => {
-  setHealth(100);
+export const resetAfterDefeat = (resetPlayer, setEnemy, setIsFighting, setMode) => {
+  resetPlayer();
   setEnemy(null);
   setIsFighting(false);
   setTimeout(() => {


### PR DESCRIPTION
## Summary
- reset entire player state when defeated
- restart the game after defeat

## Testing
- `npm test --silent` *(fails: Unable to find an element with the text /health: 95/i)*

------
https://chatgpt.com/codex/tasks/task_e_68524a978b0c83238dbb8d6f201f3afe